### PR TITLE
Remove unnecessary puts from Gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -267,26 +267,14 @@ def gen_json_for( country )
   FileUtils.mkdir_p( File.dirname( path_html ) )
   FileUtils.mkdir_p( File.dirname( path_json ) )
 
-
   page = Factbook::Page.new( country_code )
 
-  ## print first 600 chars
-  pp page.html[0..600]
-
-  ## save for debuging
-  
-  puts "saving a copy to #{country_path}.html for debugging"
   File.open( path_html, 'w') do |f|
       f.write( page.html )
   end
 
   h = page.data
-  ## pp h
-
-  ### save to json
-  puts "saving a copy to #{country_path}.json for debugging"
   File.open( path_json, 'w') do |f|
     f.write( JSON.pretty_generate( h ) )
   end
 end
-

--- a/Rakefile
+++ b/Rakefile
@@ -257,7 +257,6 @@ end
 
 
 def gen_json_for( country )
-
   country_code = country[0]
   country_path = country[1]
 

--- a/lib/factbook.rb
+++ b/lib/factbook.rb
@@ -17,9 +17,3 @@ require 'nokogiri'
 require 'factbook/version' # let it always go first
 require 'factbook/page'
 require 'factbook/sect'
-
-
-
-
-puts Factbook.banner
-

--- a/lib/factbook.rb
+++ b/lib/factbook.rb
@@ -1,7 +1,6 @@
 # encoding: utf-8
 
 ## stdlibs
-
 require 'net/http'
 require 'uri'
 require 'cgi'
@@ -9,17 +8,12 @@ require 'pp'
 require 'json'
 require 'fileutils'
 
-
 ## 3rd party gems/libs
-## require 'props'
-
 require 'logutils'
 require 'fetcher'
 require 'nokogiri'
 
-
 # our own code
-
 require 'factbook/version' # let it always go first
 require 'factbook/page'
 require 'factbook/sect'


### PR DESCRIPTION
The output to the logs can become very distracting while developing an application that includes this gem. Even when I'm not working in areas of the app that touch the factbook, I've found it is very noisy. This PR removes some puts that don't need to be included.
