### PR TITLE
add exception handling to download of json datasets

### DIFF
--- a/2021/download.rb
+++ b/2021/download.rb
@@ -1,5 +1,5 @@
 ###
-#  download all json datasets
+#  download all json datasets to Webget cache
 
 
 
@@ -11,22 +11,26 @@ Webget.config.sleep = 0.5     ## sleep 500 ms (that is, 0.5 secs)
 
 def download
   ## for debugging select some codes
-  ## codes = Factbook.codes.select {|code| ['us', 'au'].include?( code.code ) }
+  codes = Factbook.codes.select {|code| ['us', 'au'].include?( code.code ) }
 
-  codes = Factbook.codes
+  ##codes = Factbook.codes
 
   i = 0
   codes.each do |code|
-    puts "==> [#{i+1}/#{codes.size}] #{code.format}:"
+    begin ## exception handling as requested in issue #7 -> if one download fails we'll move on to the next one
+      puts "==> [#{i+1}/#{codes.size}] #{code.format}:"
 
-    res = Webget.call( code.data_url )  ## get json dataset / page
-    if res.status.nok?
-      puts "!! ERROR - download json call:"
-      pp res
-      exit 1
+      res = Webget.call( code.data_url )  ## get json dataset / page
+      if res.status.nok?
+        puts "!! ERROR - download json call:"
+        pp res
+        exit 1
+      end
+
+      i += 1
+    rescue
+      puts "!! ERROR - download json call for '%s' failed! -> moving on to the next code " %[code.data_url]
     end
-
-    i += 1
   end
   puts "bye"
 end

--- a/2021/download.rb
+++ b/2021/download.rb
@@ -11,9 +11,9 @@ Webget.config.sleep = 0.5     ## sleep 500 ms (that is, 0.5 secs)
 
 def download
   ## for debugging select some codes
-  codes = Factbook.codes.select {|code| ['us', 'au'].include?( code.code ) }
+  ##codes = Factbook.codes.select {|code| ['us', 'au'].include?( code.code ) }
 
-  ##codes = Factbook.codes
+  codes = Factbook.codes
 
   i = 0
   codes.each do |code|


### PR DESCRIPTION
As mentioned in issue #7 the GitHub action updating the json data from the Factbook source aborts on downloads from time to time. While the reason for the return HTTP error code 404 remains unclear integrating exception handling does seem reasonable to me. To my understanding it's the main objective of this repo to archive/mirror the contents of the Factbook source. So downloading as much as technically possible does serve this purpose. At least from my own point of view.

I'd like to point out that I lack any experience of coding in ruby so please double check the code for any typos.