### PR TITLE
update GitHub Actions (checkout and setup-ruby)

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,9 +21,9 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.6' # Version range or exact version of a Ruby version to use, using semvers version range syntax.
 


### PR DESCRIPTION
Hi @geraldb,

I hope you are doing well.

I noticed a few days ago that GitHub adds a **deprecation warning** to the Actions runs of this repo:[^1]

![node.js deprecation warning](https://user-images.githubusercontent.com/90517741/200632847-41170e05-0aa4-41fe-88ee-06dbd59ab0fb.png)

As mentioned in the picture above this concerns the Node.js version used by the GitHub Actions (`checkout` and `setup-ruby`).[^2]

While trying to upgrade the versions I noticed that [`actions/setup-ruby`](https://web.archive.org/web/20221108171435/https://github.com/actions/setup-ruby) is deprecated and replaced by [`ruby/setup-ruby`](https://github.com/ruby/setup-ruby).

Hope you might be have the time to look into this any time soon.

Cheers, Jean-Luc

[^1]: archived source: https://web.archive.org/web/20221108172939/https://github.com/factbook/factbook/actions/runs/3389731972

[^2]: Please also see this blog post: [github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).